### PR TITLE
Add additional tooling for DPS services

### DIFF
--- a/ansible/roles/dps/tasks/main.yml
+++ b/ansible/roles/dps/tasks/main.yml
@@ -333,6 +333,13 @@
     opts: noexec
     state: remounted
 
+- name: Install additional tooling
+  yum:
+    name:
+      - ksh
+      - sharutils
+    state: latest
+
 - name: Find authorized_keys and shell history files
   find:
     paths:


### PR DESCRIPTION
This change introduces additional tools to the AMI build including:

- `ksh` — for execution of DPS scripts (via `cron`) based on `ksh 93`
- `sharutils` — for access to `uuencode` for encoding/decoding of binary files