### PR TITLE
Refactor Packer build configuration

### DIFF
--- a/packer/build.pkr.hcl
+++ b/packer/build.pkr.hcl
@@ -4,9 +4,9 @@ build {
   ]
 
   provisioner "ansible" {
-    host_alias = "${var.ansible_host_alias}"
+    host_alias    = "${var.ansible_host_alias}"
     playbook_file = "${var.playbook_file_path}"
-    extra_arguments  = [
+    extra_arguments = [
       "-e", "aws_region=${var.aws_region}",
       "-e", "resource_bucket_c_libraries_prefix=${var.resource_bucket_c_libraries_prefix}",
       "-e", "resource_bucket_name=${var.resource_bucket_name}",

--- a/packer/packer.pkr.hcl
+++ b/packer/packer.pkr.hcl
@@ -1,0 +1,12 @@
+packer {
+  required_plugins {
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = ">= 1.3, < 1.4"
+    }
+    ansible = {
+      source  = "github.com/hashicorp/ansible"
+      version = ">= 1.1, < 1.2"
+    }
+  }
+}

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -47,26 +47,26 @@ source "amazon-ebs" "builder" {
 
   security_group_filter {
     filters = {
-      "group-name": "packer-builders-${var.aws_region}"
+      "group-name" : "packer-builders-${var.aws_region}"
     }
   }
 
   source_ami_filter {
     filters = {
       virtualization-type = "hvm"
-      name =  "${var.aws_source_ami_filter_name}"
-      root-device-type = "ebs"
+      name                = "${var.aws_source_ami_filter_name}"
+      root-device-type    = "ebs"
     }
-    owners = ["${var.aws_source_ami_owner_id}"]
+    owners      = ["${var.aws_source_ami_owner_id}"]
     most_recent = true
   }
 
   subnet_filter {
     filters = {
-          "tag:Name": "${var.aws_subnet_filter_name}"
+      "tag:Name" : "${var.aws_subnet_filter_name}"
     }
     most_free = true
-    random = false
+    random    = false
   }
 
   run_tags = {

--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -4,6 +4,7 @@ source "amazon-ebs" "builder" {
   communicator              = "ssh"
   force_delete_snapshot     = var.force_delete_snapshot
   force_deregister          = var.force_deregister
+  imds_support              = "v2.0"
   instance_type             = var.aws_instance_type
   region                    = var.aws_region
   ssh_clear_authorized_keys = var.ssh_clear_authorized_keys
@@ -38,6 +39,12 @@ source "amazon-ebs" "builder" {
     }
   }
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
   security_group_filter {
     filters = {
       "group-name": "packer-builders-${var.aws_region}"
@@ -62,8 +69,19 @@ source "amazon-ebs" "builder" {
     random = false
   }
 
-  tags = {
+  run_tags = {
+    AMI     = "${var.ami_name_prefix}"
+    Name    = "packer-builder-${var.ami_name_prefix}-${var.version}"
+    Service = "packer-builder"
+  }
+
+  run_volume_tags = {
     Builder = "packer-{{packer_version}}"
     Name    = "${var.ami_name_prefix}-${var.version}"
+  }
+
+  tags = {
+    Name    = "${var.ami_name_prefix}-${var.version}"
+    Builder = "packer-{{packer_version}}"
   }
 }


### PR DESCRIPTION
These changes bring the Packer build configuration into alignment with our [AMI build template](https://github.com/companieshouse/ami-repository-template/) and include the following:

- Add EC2 instance runtime and EBS volume tags
- Enforce the use of IMDSv2 session tokens
- Include explicit plugin sources and version constraints
- Reformat Packer source files